### PR TITLE
Changing classes to "new-style" classes

### DIFF
--- a/gdspy/__init__.py
+++ b/gdspy/__init__.py
@@ -21,6 +21,9 @@
 ########################################################################
 
 from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
 
 import struct
 import datetime
@@ -101,7 +104,7 @@ def _eight_byte_real_to_float(value):
     return (-1 if (short1 & 0x8000) else 1) * mantissa * 16L ** (exponent - 64)
 
 
-class Polygon:
+class Polygon(object):
     """
     Polygonal geometric object.
 
@@ -354,7 +357,7 @@ class Polygon:
 
 
 
-class PolygonSet:
+class PolygonSet(object):
     """
     Set of polygonal objects.
 
@@ -1739,7 +1742,7 @@ class PolyPath(PolygonSet):
         return "PolyPath ({} polygons, {} vertices, layers {}, datatypes {})".format(len(self.polygons), sum([len(p) for p in self.polygons]), list(set(self.layers)), list(set(self.datatypes)))
 
 
-class Label:
+class Label(object):
     """
     Text that can be used to label parts of the geometry or display
     messages. The text does not create additional geometry, it's meant for
@@ -1860,7 +1863,7 @@ class Label:
 
 
 
-class Cell:
+class Cell(object):
     """
     Collection of elements, both geometric objects and references to other
     cells.
@@ -2219,7 +2222,7 @@ class Cell:
         return self
 
 
-class CellReference:
+class CellReference(object):
     """
     Simple reference to an existing cell.
 
@@ -2441,7 +2444,7 @@ class CellReference:
 
 
 
-class CellArray:
+class CellArray(object):
     """
     Multiple references to an existing cell in an array format.
 
@@ -2695,7 +2698,7 @@ class CellArray:
 
 
 
-class GdsImport:
+class GdsImport(object):
     """
     Object used to import structures from a GDSII stream file.
 
@@ -3441,7 +3444,7 @@ def gds_print(outfile, cells=None, name='library', unit=1.0e-6, precision=1.0e-9
         outfile.close()
 
 
-class GdsPrint:
+class GdsPrint(object):
     """
     GDSII strem library printer.
 

--- a/gdspy/__init__.py
+++ b/gdspy/__init__.py
@@ -22,7 +22,6 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
-from __future__ import unicode_literals
 from __future__ import division
 
 import struct
@@ -35,7 +34,7 @@ from gdspy import boolext
 from gdspy import clipper
 from gdspy.viewer import LayoutViewer
 
-__version__ = '0.9'
+__version__ = '0.91'
 __doc__ = """
 gdspy is a Python module that allows the creation of GDSII stream files.
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ else:
     from distutils.command.build_py import build_py
 import distutils.command.build_ext
 
-from distutils.core import setup, Extension
+from setuptools import setup, Extension
 
 class my_build(distutils.command.build_ext.build_ext):
     def run(self):
@@ -38,7 +38,7 @@ class my_build(distutils.command.build_ext.build_ext):
             if os.path.isfile(f + 'pyc'): os.unlink(f + 'pyc')
 
 setup(name='gdspy',
-      version='0.9',
+      version='0.91',
       author='Lucas Heitzmann Gabrielli',
       author_email='heitzmann@gmail.com',
       license='GNU General Public License (GPL)',

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ else:
     from distutils.command.build_py import build_py
 import distutils.command.build_ext
 
-from setuptools import setup, Extension
+from distutils.core import setup, Extension
 
 class my_build(distutils.command.build_ext.build_ext):
     def run(self):
@@ -38,7 +38,7 @@ class my_build(distutils.command.build_ext.build_ext):
             if os.path.isfile(f + 'pyc'): os.unlink(f + 'pyc')
 
 setup(name='gdspy',
-      version='0.91',
+      version='0.9',
       author='Lucas Heitzmann Gabrielli',
       author_email='heitzmann@gmail.com',
       license='GNU General Public License (GPL)',


### PR DESCRIPTION
To bring gdspy more in line with 2.7+ and into 3, I changed the types of the base classes (Cell, Polygon, etc) to be "new-style".  This should allow anyone to use the super() function effectively when they subclass off any of the base classes in gdspy.  It also allows the usage of the type() function, so instead of 
`if (layer.__class__ != [].__class__):`
we can now do
`if type(layer) is list:`

which is a lot more straightforward.

http://stackoverflow.com/questions/54867/what-is-the-difference-between-old-style-and-new-style-classes-in-python

I also changed the distutils.core functions to setuptools in setup.py, which from my understanding.  I will admit I only did this because I couldn't get distutils to actually find my C compiler!  That small change should be tested on someone else's end to make sure it's still compatible.

http://stackoverflow.com/questions/25337706/setuptools-vs-distutils-why-is-distutils-still-a-thing