### PR TITLE
Replace numpy inplace operations with explicit versions

### DIFF
--- a/gdspy/__init__.py
+++ b/gdspy/__init__.py
@@ -377,7 +377,7 @@ class Polygon(object):
         >>> myCell.add(polygon)
         """
 
-        self.points += [dx, dy]
+        self.points = self.points + [dx, dy]
 
         return self
 
@@ -673,7 +673,7 @@ class PolygonSet(object):
             This object.
         """
         for ii in range(len(self.polygons)):
-            self.polygons[ii] += [dx, dy]
+            self.polygons[ii] = self.polygons[ii] + [dx, dy]
 
         return self
 


### PR DESCRIPTION
Inplace operations have been changed in newer versions of numpy, and trying to sum two arrays of different types no longer completes nicely.  For instance, if a gdspy.Polygon happens to end up with points of dtype 'int32', when you try to do translate(dx=1.2, dy = 1.3) (adding a float), you get an error like: 
`TypeError: Cannot cast ufunc add output from dtype('float64') to dtype('int32') with casting rule 'same_kind'`

For instance, in newer versions of numpy the following works:
```
x = np.array([1,2], dtype = 'int32')
y = np.array([4,6], dtype = 'float64')
x = x + y   
```

But this does not:

```
x = np.array([1,2], dtype = 'int32')
y = np.array([4,6], dtype = 'float64')
x += y   
```


See e.g. [this explanation](https://github.com/numpy/numpy/issues/6198) or [this explanation](http://stackoverflow.com/questions/12588986/typeerror-ufunc-when-using-on-numpy-arrays)