### PR TITLE
Remove LayoutViewer import, to allow using main library without tkinter

### DIFF
--- a/gdspy/__init__.py
+++ b/gdspy/__init__.py
@@ -45,6 +45,10 @@ import hashlib
 
 from gdspy import boolext
 from gdspy import clipper
+try:
+    from gdspy.viewer import LayoutViewer
+except ImportError as e:
+    warnings.warn("[GDSPY] LayoutViewer not available: " + str(e), category=ImportWarning, stacklevel=2)
 
 __version__ = '1.1.2'
 

--- a/gdspy/__init__.py
+++ b/gdspy/__init__.py
@@ -45,7 +45,6 @@ import hashlib
 
 from gdspy import boolext
 from gdspy import clipper
-from gdspy.viewer import LayoutViewer
 
 __version__ = '1.1.2'
 


### PR DESCRIPTION
I would like to use this library just for reading/writing GDS files in a headless environment without any graphical toolkit installed, but the main module imports `gdspy.viewer`, which pulls `tkinter`. This pull request removes the import, which appears to be unused anyway.