### PR TITLE
Fix to check properly for string type in both Python 2 and Python 3

### DIFF
--- a/gdspy/__init__.py
+++ b/gdspy/__init__.py
@@ -36,6 +36,15 @@ if sys.version_info.major < 3:
     from future import standard_library
     standard_library.install_aliases()
 
+#Python 3 doesn't have basestring as unicode is type string
+#Python 2 doesn't equate unicode to string, but both are basestring
+try:
+    basestring
+except NameError:
+    basestring = str
+#Now isinstance(s, basestring) will be True for any python string type
+
+
 import struct
 import datetime
 import warnings
@@ -1541,7 +1550,7 @@ class Path(PolygonSet):
         sa = numpy.sin(angle)
         sa = numpy.array((-sa, sa))
         c0 = numpy.array(center)
-        if isinstance(self.direction, str):
+        if isinstance(self.direction, basestring):
             self.direction = _directions_dict[self.direction] * numpy.pi
         self.direction += angle
         cur = numpy.array((self.x, self.y)) - c0
@@ -3739,7 +3748,7 @@ class GdsLibrary(object):
         overwrite_duplicate : bool
             If True an existing cell with the same name in the library will be
             overwritten.
-        
+
         Returns
         -------
         out : ``GdsLibrary``
@@ -3789,7 +3798,7 @@ class GdsLibrary(object):
         Only the specified cells are written.  The user is responsible for
         ensuring all cell dependencies are satisfied.
         """
-        if isinstance(outfile, str):
+        if isinstance(outfile, basestring):
             outfile = open(outfile, 'wb')
             close = True
         else:
@@ -3851,7 +3860,7 @@ class GdsLibrary(object):
         imported file.
         """
         self._references = []
-        if isinstance(infile, str):
+        if isinstance(infile, basestring):
             infile = open(infile, 'rb')
             close = True
         else:
@@ -4101,7 +4110,7 @@ class GdsLibrary(object):
     def top_level(self):
         """
         Output the top level cells from the GDSII data.
-        
+
         Top level cells are those that are not referenced by any other cells.
 
         Returns
@@ -4160,7 +4169,7 @@ class GdsWriter(object):
     """
 
     def __init__(self, outfile, name='library', unit=1.0e-6, precision=1.0e-9):
-        if isinstance(outfile, str):
+        if isinstance(outfile, basestring):
             self._outfile = open(outfile, 'wb')
             self._close = True
         else:

--- a/gdspy/__init__.py
+++ b/gdspy/__init__.py
@@ -35,14 +35,12 @@ if sys.version_info.major < 3:
 
     from future import standard_library
     standard_library.install_aliases()
-
-#Python 3 doesn't have basestring as unicode is type string
-#Python 2 doesn't equate unicode to string, but both are basestring
-try:
-    basestring
-except NameError:
+else:
+    #Python 3 doesn't have basestring, as unicode is type string
+    #Python 2 doesn't equate unicode to string, but both are basestring
+    #Now isinstance(s, basestring) will be True for any python string type
     basestring = str
-#Now isinstance(s, basestring) will be True for any python string type
+
 
 
 import struct


### PR DESCRIPTION
There is a bug currently when running `gdspy` under Python 2 where if a unicode string is used for a filename for either `.read_gds` or `.write_gds` methods `gdspy` will crash. The fix is to test for type `basestring` instead of type `str` in Python 2. Python 3 lacks type `basestring` as all strings are naturally unicode and so this fix sets `basestring = str` if Python 3+ is detected.