### PR TITLE
Store parameters of 'Round' object upon creation

### DIFF
--- a/gdspy/__init__.py
+++ b/gdspy/__init__.py
@@ -864,7 +864,8 @@ class Round(PolygonSet):
     ...                       final_angle=0)
     """
 
-    __slots__ = 'layers', 'datatypes', 'polygons'
+    __slots__ = ('layers', 'datatypes', 'polygons', 'center', 'radius',
+                 'initial_angle', 'final_angle')
 
     def __init__(self,
                  center,
@@ -876,6 +877,8 @@ class Round(PolygonSet):
                  max_points=199,
                  layer=0,
                  datatype=0):
+
+
         if isinstance(number_of_points, float):
             if inner_radius <= 0:
                 if final_angle == initial_angle:
@@ -898,6 +901,10 @@ class Round(PolygonSet):
         number_of_points = number_of_points // pieces
         self.layers = [layer] * pieces
         self.datatypes = [datatype] * pieces
+        self.center = center
+        self.radius = radius
+        self.initial_angle = initial_angle
+        self.final_angle = final_angle
         self.polygons = [
             numpy.zeros((number_of_points, 2)) for _ in range(pieces)
         ]

--- a/gdspy/__init__.py
+++ b/gdspy/__init__.py
@@ -877,8 +877,7 @@ class Round(PolygonSet):
                  max_points=199,
                  layer=0,
                  datatype=0):
-
-
+        
         if isinstance(number_of_points, float):
             if inner_radius <= 0:
                 if final_angle == initial_angle:


### PR DESCRIPTION
I'm working on a [GDS to Latex converter](https://github.com/Aypac/GDSLatexConverter) right now. TikZ (as opposed to GDS) supports the direct plotting of circles. In order to save resources, I would like to provide an option to directly access the parameters used to create circular structures. Thus this simple addition.

As far as I understand, this solution does not work when loading GDS files into gdspy, but I still believe that it is better than nothing. Please consider adopting this change.