### PR TITLE
Enable template rename in read_gds

### DIFF
--- a/gdspy/__init__.py
+++ b/gdspy/__init__.py
@@ -3408,6 +3408,7 @@ class GdsLibrary(object):
                  infile,
                  units='skip',
                  rename={},
+                 prefix='',
                  layers={},
                  datatypes={},
                  texttypes={}):
@@ -3430,6 +3431,8 @@ class GdsLibrary(object):
         rename : dictionary
             Dictionary used to rename the imported cells.  Keys and
             values must be strings.
+        prefix : string
+            String to be prefixed to names of the imported cells.
         layers : dictionary
             Dictionary used to convert the layers in the imported cells.
             Keys and values must be integers.
@@ -3503,7 +3506,7 @@ class GdsLibrary(object):
                 create_element = self._create_label
             # SNAME
             elif record[0] == 0x12:
-                kwargs['ref_cell'] = rename.get(record[1], record[1])
+                kwargs['ref_cell'] = prefix + rename.get(record[1], record[1])
             # COLROW
             elif record[0] == 0x13:
                 kwargs['columns'] = record[1][0]
@@ -3533,7 +3536,7 @@ class GdsLibrary(object):
                 create_element = self._create_array
             # STRNAME
             elif record[0] == 0x06:
-                name = rename.get(record[1], record[1])
+                name = prefix + rename.get(record[1], record[1])
                 cell = Cell(name, exclude_from_current=True)
                 self.cell_dict[name] = cell
             # STRING

--- a/gdspy/__init__.py
+++ b/gdspy/__init__.py
@@ -3408,10 +3408,10 @@ class GdsLibrary(object):
                  infile,
                  units='skip',
                  rename={},
+                 rename_template='{name}',
                  layers={},
                  datatypes={},
-                 texttypes={},
-                 rename_template='{name}'):
+                 texttypes={}):
         """
         Read a GDSII file into this library.
 

--- a/gdspy/__init__.py
+++ b/gdspy/__init__.py
@@ -3408,10 +3408,10 @@ class GdsLibrary(object):
                  infile,
                  units='skip',
                  rename={},
-                 prefix='',
                  layers={},
                  datatypes={},
-                 texttypes={}):
+                 texttypes={},
+                 prefix=''):
         """
         Read a GDSII file into this library.
 
@@ -3431,8 +3431,6 @@ class GdsLibrary(object):
         rename : dictionary
             Dictionary used to rename the imported cells.  Keys and
             values must be strings.
-        prefix : string
-            String to be prefixed to names of the imported cells.
         layers : dictionary
             Dictionary used to convert the layers in the imported cells.
             Keys and values must be integers.
@@ -3442,6 +3440,8 @@ class GdsLibrary(object):
         texttypes : dictionary
             Dictionary used to convert the text types in the imported
             cells.  Keys and values must be integers.
+        prefix : string
+            String to be prefixed to names of the imported cells.
 
         Returns
         -------

--- a/gdspy/__init__.py
+++ b/gdspy/__init__.py
@@ -3431,6 +3431,10 @@ class GdsLibrary(object):
         rename : dictionary
             Dictionary used to rename the imported cells.  Keys and
             values must be strings.
+        rename_template : string
+            Template string used to rename the imported cells. Appiled
+            only if the cell name is not in the ``rename`` dictionary.
+            Examples: ``'prefix-{name}'``, ``'{name}-suffix'``
         layers : dictionary
             Dictionary used to convert the layers in the imported cells.
             Keys and values must be integers.
@@ -3440,10 +3444,6 @@ class GdsLibrary(object):
         texttypes : dictionary
             Dictionary used to convert the text types in the imported
             cells.  Keys and values must be integers.
-        rename_template : string
-            Template string used to rename the imported cells. Appiled
-            only if the cell name is not in the ``rename`` dictionary.
-            Examples: ``'prefix-{name}'``, ``'{name}-suffix'``
 
         Returns
         -------

--- a/gdspy/__init__.py
+++ b/gdspy/__init__.py
@@ -3443,7 +3443,7 @@ class GdsLibrary(object):
         rename_template : string
             Template string used to rename the imported cells. Appiled
             only if the cell name is not in the ``rename`` dictionary.
-            Examples: ``'prefix-{name}'``, ``'{name}-postfix'``
+            Examples: ``'prefix-{name}'``, ``'{name}-suffix'``
 
         Returns
         -------

--- a/gdspy/__init__.py
+++ b/gdspy/__init__.py
@@ -3411,7 +3411,7 @@ class GdsLibrary(object):
                  layers={},
                  datatypes={},
                  texttypes={},
-                 prefix=''):
+                 rename_template='{name}'):
         """
         Read a GDSII file into this library.
 
@@ -3440,8 +3440,10 @@ class GdsLibrary(object):
         texttypes : dictionary
             Dictionary used to convert the text types in the imported
             cells.  Keys and values must be integers.
-        prefix : string
-            String to be prefixed to names of the imported cells.
+        rename_template : string
+            Template string used to rename the imported cells. Appiled
+            only if the cell name is not in the ``rename`` dictionary.
+            Examples: ``'prefix-{name}'``, ``'{name}-postfix'``
 
         Returns
         -------
@@ -3506,7 +3508,11 @@ class GdsLibrary(object):
                 create_element = self._create_label
             # SNAME
             elif record[0] == 0x12:
-                kwargs['ref_cell'] = prefix + rename.get(record[1], record[1])
+                if record[1] in rename:
+                    name = rename[record[1]]
+                else:
+                    name = rename_template.format(name=record[1])
+                kwargs['ref_cell'] = name
             # COLROW
             elif record[0] == 0x13:
                 kwargs['columns'] = record[1][0]
@@ -3536,7 +3542,10 @@ class GdsLibrary(object):
                 create_element = self._create_array
             # STRNAME
             elif record[0] == 0x06:
-                name = prefix + rename.get(record[1], record[1])
+                if record[1] in rename:
+                    name = rename[record[1]]
+                else:
+                    name = rename_template.format(name=record[1])
                 cell = Cell(name, exclude_from_current=True)
                 self.cell_dict[name] = cell
             # STRING

--- a/tests/gdswriter.py
+++ b/tests/gdswriter.py
@@ -29,8 +29,8 @@ def test_writer_gds(tmpdir):
         writer1.write_cell(c)
     writer1.close()
     lib1 = gdspy.GdsLibrary(unit=1e-3)
-    lib1.read_gds(fname1, 'convert', {'gw_rw_gds_1': '1'}, {2: 4}, {4: 2},
-                  {6: 7})
+    lib1.read_gds(fname1, units='convert', rename={'gw_rw_gds_1': '1'},
+            layers={2: 4}, datatypes={4: 2}, texttypes={6: 7})
     assert lib1.name == 'lib'
     assert len(lib1.cell_dict) == 4
     assert set(lib1.cell_dict.keys()) == {


### PR DESCRIPTION
Keyword argument `rename` in `read_gds` is a dictionary and is useless for reading a file with unknown cell names.
The new keyword argument `prefix` enables prefixing to all cell names.