### PR TITLE
Fracturing in Path object's parametric function

### DIFF
--- a/gdspy/__init__.py
+++ b/gdspy/__init__.py
@@ -2232,7 +2232,11 @@ class Path(PolygonSet):
         self.y = x0[-1, 1]
         self.direction = numpy.arctan2(-dx[-1, 0], dx[-1, 1])
 
-        max_points = min(np, max_points // 2)
+        if max_points < 4:
+            max_points = np
+        else:
+            max_points = max_points//2
+            
         i0 = 0
         while i0 < np - 1:
             i1 = min(i0 + max_points, np)

--- a/gdspy/__init__.py
+++ b/gdspy/__init__.py
@@ -2232,7 +2232,7 @@ class Path(PolygonSet):
         self.y = x0[-1, 1]
         self.direction = numpy.arctan2(-dx[-1, 0], dx[-1, 1])
 
-        max_points = max(np, max_points // 2)
+        max_points = min(np, max_points // 2)
         i0 = 0
         while i0 < np - 1:
             i1 = min(i0 + max_points, np)


### PR DESCRIPTION
Currently, the `parametric` function does not fracture the path when the number of computed points is greater than `max_points`.  I believe it is because max_points (on line 2235) takes the max value of `np` (the number of computed points) and `max_points//2`.  I think this should be the *min* of the two, since if `np > max_points`, there should be fracturing.  Please let me know if I overlooked something.