### PR TITLE
fix write_svg with style, fontstyle

### DIFF
--- a/gdspy/library.py
+++ b/gdspy/library.py
@@ -854,10 +854,10 @@ class Cell(object):
         )
         ldkeys, ltkeys = self.get_svg_classes()
         for k in ldkeys:
+            l, d = k
             if k in style:
                 style_dict = style[k]
             else:
-                l, d = k
                 c = "rgb({}, {}, {})".format(
                     *[
                         int(255 * c + 0.5)
@@ -873,10 +873,10 @@ class Cell(object):
             outfile.write(" ".join("{}: {};".format(*x) for x in style_dict.items()))
             outfile.write("}\n")
         for k in ltkeys:
+            l, t = k
             if k in fontstyle:
                 style_dict = fontstyle[k]
             else:
-                l, t = k
                 c = "rgb({}, {}, {})".format(
                     *[
                         int(255 * c + 0.5)

--- a/tests/cell.py
+++ b/tests/cell.py
@@ -11,6 +11,7 @@ import pytest
 import gdspy
 import numpy
 import uuid
+import os
 
 gdspy.library.use_current_library = False
 
@@ -220,3 +221,18 @@ def test_get_polygons3():
     assert len(c0.get_polygons()) == 0
     assert len(c0.get_polygons(True)) == 0
     assert len(c0.get_polygons(False, -1)) == 0
+
+def test_write_svg(tree, tmpdir):
+    _, _, c1 = tree
+    fname = str(tmpdir.join("c1.svg"))
+    c1.write_svg(fname)
+    assert os.path.isfile(fname)
+    assert not os.stat(fname).st_size == 0
+
+def test_write_svg_with_style(tree, tmpdir):
+    _, _, c1 = tree
+    fname = str(tmpdir.join("c1.svg"))
+    style = {(0, 0): {"fill": "CC00FF"}}
+    c1.write_svg(fname, style=style)
+    assert os.path.isfile(fname)
+    assert not os.stat(fname).st_size == 0


### PR DESCRIPTION
currently, if a style defines a valid layer (and datatype) then `l`, `t`, and `d` aren't properly defined. this fix moves the assignment.