### PR TITLE
CellReference.to_gds() can fail when using a missing reference

### DIFF
--- a/gdspy/library.py
+++ b/gdspy/library.py
@@ -982,7 +982,10 @@ class CellReference(object):
             A number that multiplies all dimensions written in the GDSII
             element.
         """
-        name = self.ref_cell.name
+        if isinstance(self.ref_cell, Cell):
+            name = self.ref_cell.name
+        else:
+            name = self.ref_cell
         if len(name) % 2 != 0:
             name = name + "\0"
         outfile.write(struct.pack(">4H", 4, 0x0A00, 4 + len(name), 0x1206))

--- a/gdspy/library.py
+++ b/gdspy/library.py
@@ -1445,7 +1445,10 @@ class CellArray(object):
             A number that multiplies all dimensions written in the GDSII
             element.
         """
-        name = self.ref_cell.name
+        if isinstance(self.ref_cell, Cell):
+            name = self.ref_cell.name
+        else:
+            name = self.ref_cell
         if len(name) % 2 != 0:
             name = name + "\0"
         outfile.write(struct.pack(">4H", 4, 0x0B00, 4 + len(name), 0x1206))

--- a/tests/functions.py
+++ b/tests/functions.py
@@ -319,3 +319,12 @@ def test_missing_cr(tmpdir):
     out = str(tmpdir.join("test.gds"))
     now = datetime.datetime.today()
     lib.write_gds(out, timestamp=now)
+
+def test_missing_ca(tmpdir):
+    lib = gdspy.GdsLibrary()
+    c1 = gdspy.Cell("cell1")
+    c1.add(gdspy.CellArray("missing", (0, 0), -42, 2, True, ignore_missing=True))
+    lib.add(c1)
+    out = str(tmpdir.join("test.gds"))
+    now = datetime.datetime.today()
+    lib.write_gds(out, timestamp=now)

--- a/tests/functions.py
+++ b/tests/functions.py
@@ -310,3 +310,12 @@ def test_get_binary_cells(library, tmpdir):
         bindata = binfile.getvalue()
         assert bindata == bincells[name]
         binfile.close()
+
+def test_missing_cr(tmpdir):
+    lib = gdspy.GdsLibrary()
+    c1 = gdspy.Cell("cell1")
+    c1.add(gdspy.CellReference("missing", (0, 0), -42, 2, True, ignore_missing=True))
+    lib.add(c1)
+    out = str(tmpdir.join("test.gds"))
+    now = datetime.datetime.today()
+    lib.write_gds(out, timestamp=now)


### PR DESCRIPTION
because the `ref_cell` could be a `str`.

copy-pasta-ing the `name` conditional from `to_svg`.