### PR TITLE
fix test and use valid CellArray parameters

### DIFF
--- a/tests/functions.py
+++ b/tests/functions.py
@@ -323,7 +323,7 @@ def test_missing_cr(tmpdir):
 def test_missing_ca(tmpdir):
     lib = gdspy.GdsLibrary()
     c1 = gdspy.Cell("cell1")
-    c1.add(gdspy.CellArray("missing", (0, 0), -42, 2, True, ignore_missing=True))
+    c1.add(gdspy.CellArray("missing", 2, 3, (1, 4), (-1, -2), 180, 0.5, True, ignore_missing=True))
     lib.add(c1)
     out = str(tmpdir.join("test.gds"))
     now = datetime.datetime.today()


### PR DESCRIPTION
:bug: caused by 9eacd34020a02f049ec219bc29d39e9293c1fbd1 using bad
copypasta arguments from analogous `CellReference` test.