### PR TITLE
Faster bounding box for CellReference

### DIFF
--- a/gdspy/library.py
+++ b/gdspy/library.py
@@ -1468,11 +1468,10 @@ class CellReference(object):
         if not isinstance(self.ref_cell, Cell):
             return None
 
-        cell_bbox = self.ref_cell.get_bounding_box()
-        if cell_bbox is None:
-            return None
-
         if self.rotation is None or self.rotation % 90 == 0:
+            cell_bbox = self.ref_cell.get_bounding_box()
+            if cell_bbox is None:
+                return None
             polygons = [cell_bbox]
             self._transform_polygons(polygons)
         else:

--- a/gdspy/library.py
+++ b/gdspy/library.py
@@ -1467,11 +1467,17 @@ class CellReference(object):
         """
         if not isinstance(self.ref_cell, Cell):
             return None
+
         cell_bbox = self.ref_cell.get_bounding_box()
         if cell_bbox is None:
             return None
-        polygons = [cell_bbox]
-        self._transform_polygons(polygons)
+
+        if self.rotation is None or self.rotation % 90 == 0:
+            polygons = [cell_bbox]
+            self._transform_polygons(polygons)
+        else:
+            # for non-cardinal rotations of a reference, we must use the flattened polygons for the reference
+            polygons = self.get_polygons()
         if len(polygons) == 0:
             bb = None
         else:

--- a/gdspy/library.py
+++ b/gdspy/library.py
@@ -1276,8 +1276,6 @@ class CellReference(object):
         Instances of `FlexPath` and `RobustPath` are also included in
         the result by computing their polygonal boundary.
         """
-        if not isinstance(self.ref_cell, Cell):
-            return dict() if by_spec else []
         if self.rotation is not None:
             ct = numpy.cos(self.rotation * numpy.pi / 180.0)
             st = numpy.sin(self.rotation * numpy.pi / 180.0) * _mpone
@@ -1341,6 +1339,8 @@ class CellReference(object):
         Instances of `FlexPath` and `RobustPath` are also included in
         the result by computing their polygonal boundary.
         """
+        if not isinstance(self.ref_cell, Cell):
+            return dict() if by_spec else []
         polygons = self.ref_cell.get_polygons(by_spec, depth)
         self._transform_polygons(polygons, by_spec=by_spec)
         return polygons

--- a/gdspy/library.py
+++ b/gdspy/library.py
@@ -1472,15 +1472,9 @@ class CellReference(object):
         """
         if not isinstance(self.ref_cell, Cell):
             return None
-        deps = self.ref_cell.get_dependencies(True)
-        for ref in deps:
-            ref.get_bounding_box()
         cell_bbox = self.ref_cell.get_bounding_box()
         polygons = [cell_bbox]
         self._transform_polygons(polygons)
-        tmp = self.origin
-        self.origin = None
-        self.origin = tmp
         if len(polygons) == 0:
             bb = None
         else:
@@ -1491,12 +1485,7 @@ class CellReference(object):
                     (all_points[0].max(), all_points[1].max()),
                 )
             )
-        if self.origin is None or bb is None:
-            return bb
-        else:
-            return bb + numpy.array(
-                ((self.origin[0], self.origin[1]), (self.origin[0], self.origin[1]))
-            )
+        return bb
 
     def translate(self, dx, dy):
         """

--- a/gdspy/library.py
+++ b/gdspy/library.py
@@ -1252,24 +1252,21 @@ class CellReference(object):
             else:
                 return self.ref_cell.area() * self.magnification ** 2
 
-    def _transform_polygons(self, polygons, by_spec=False):
+    def _transform_polygons(self, polygons):
         """
         Transforms a set of polygons based on the CellReference's applied transformations.
 
         Parameters
         ----------
-        by_spec : bool or tuple
-            If True, the return value is a dictionary with the
-            polygons of each individual pair (layer, datatype).
-            If set to a tuple of (layer, datatype), only polygons
-            with that specification are returned.
+        polygons : list of array-like[N][2] or dictionary
+            List containing the coordinates of the vertices of each
+            polygon, or dictionary of lists of polygons.
 
         Returns
         -------
         out : list of array-like[N][2] or dictionary
             List containing the coordinates of the vertices of each
-            polygon, or dictionary with the list of polygons (if
-            `by_spec` is True).
+            polygon, or dictionary of lists of polygons (matches format of input polygons).
 
         Note
         ----
@@ -1285,7 +1282,7 @@ class CellReference(object):
             mag = numpy.array((self.magnification, self.magnification), dtype=float)
         if self.origin is not None:
             orgn = numpy.array(self.origin)
-        if by_spec is True:
+        if isinstance(polygons, dict):
             for kk in polygons.keys():
                 for ii in range(len(polygons[kk])):
                     if self.x_reflection:
@@ -1342,7 +1339,7 @@ class CellReference(object):
         if not isinstance(self.ref_cell, Cell):
             return dict() if by_spec else []
         polygons = self.ref_cell.get_polygons(by_spec, depth)
-        self._transform_polygons(polygons, by_spec=by_spec)
+        self._transform_polygons(polygons)
         return polygons
 
     def get_polygonsets(self, depth=None):

--- a/gdspy/library.py
+++ b/gdspy/library.py
@@ -1254,7 +1254,7 @@ class CellReference(object):
 
     def _transform_polygons(self, polygons, by_spec=False):
         """
-        Return the list of polygons created by this reference.
+        Transforms a set of polygons based on the CellReference's applied transformations.
 
         Parameters
         ----------
@@ -1263,11 +1263,6 @@ class CellReference(object):
             polygons of each individual pair (layer, datatype).
             If set to a tuple of (layer, datatype), only polygons
             with that specification are returned.
-        depth : integer or None
-            If not None, defines from how many reference levels to
-            retrieve polygons.  References below this level will result
-            in a bounding box.  If `by_spec` is True the key will be the
-            name of the referenced cell.
 
         Returns
         -------

--- a/gdspy/library.py
+++ b/gdspy/library.py
@@ -1468,6 +1468,8 @@ class CellReference(object):
         if not isinstance(self.ref_cell, Cell):
             return None
         cell_bbox = self.ref_cell.get_bounding_box()
+        if cell_bbox is None:
+            return None
         polygons = [cell_bbox]
         self._transform_polygons(polygons)
         if len(polygons) == 0:

--- a/tests/cell.py
+++ b/tests/cell.py
@@ -251,7 +251,7 @@ def test_write_svg_with_style(tree, tmpdir):
 
 
 def assert_bb(bb1, bb2):
-    assert all(abs(c1 - c2) < 1e-12 for p1, p2 in zip(bb1, bb2) for c1, c2 in zip(p1, p2))
+    assert all([abs(c1 - c2) < 1e-12 for p1, p2 in zip(bb1, bb2) for c1, c2 in zip(p1, p2)])
 
 
 def test_bounding_box():

--- a/tests/cell.py
+++ b/tests/cell.py
@@ -251,7 +251,7 @@ def test_write_svg_with_style(tree, tmpdir):
 
 
 def assert_bb(bb1, bb2):
-    assert all([abs(c1 - c2) < 1e-12 for p1, p2 in zip(bb1, bb2) for c1, c2 in zip(p1, p2)])
+    assert all({abs(c1 - c2) < 1e-12 for p1, p2 in zip(bb1, bb2) for c1, c2 in zip(p1, p2)})
 
 
 def test_bounding_box():

--- a/tests/cell.py
+++ b/tests/cell.py
@@ -251,7 +251,9 @@ def test_write_svg_with_style(tree, tmpdir):
 
 
 def assert_bb(bb1, bb2):
-    assert all({abs(c1 - c2) < 1e-12 for p1, p2 in zip(bb1, bb2) for c1, c2 in zip(p1, p2)})
+    for p1, p2 in zip(bb1, bb2):
+        for c1, c2 in zip(p1, p2):
+            assert abs(c1 - c2) < 1e-12
 
 
 def test_bounding_box():


### PR DESCRIPTION
The current implementation of `get_bounding_box()` for `CellReference` becomes extremely inefficient, both in time and memory, for large hierarchical cells, because it calls `self.get_polygons(depth=None)`, which will calculate the full flattened set of shapes for a reference. For large hierarchical designs, we have found multiple issues where (1) this crashes 32 bit machines (2) this becomes the major bottleneck in execution time for PIC creation.

There is no reason why we must get the flattened set of shapes here. We only need to get the bounding box of the `ref_cell` and apply the proper transformations to it, consistent with how they are done elsewhere for `CellReference`. This PR
1. Refactors out the transformation of polygons for a `CellReference` into an internal method, `_transform_polygons()`
2. Updates `CellReference.get_polygons()` to use this new method (no change to performace)
3. Uses this new method within an updated `get_bounding_box()` method, as described above, dramatically increasing efficiency