### PR TITLE
Fix bounding box edge cases

### DIFF
--- a/gdspy/library.py
+++ b/gdspy/library.py
@@ -578,11 +578,16 @@ class Cell(object):
                 bb[0, 1] = min(bb[0, 1], all_points[1].min())
                 bb[1, 0] = max(bb[1, 0], all_points[0].max())
                 bb[1, 1] = max(bb[1, 1], all_points[1].max())
-                self._bounding_box = numpy.asarray(bb)
+                self._bounding_box = bb
             else:
                 self._bounding_box = None
             self._bb_valid = True
-        return self._bounding_box
+
+        if self._bounding_box is None:
+            return None
+        else:
+            # return a *copy* of the cached bounding box to ensure it doesn't get inadvertently modified
+            return numpy.array(self._bounding_box)
 
     def get_polygons(self, by_spec=False, depth=None):
         """

--- a/gdspy/library.py
+++ b/gdspy/library.py
@@ -577,16 +577,15 @@ class Cell(object):
             for reference in self.references:
                 reference_bb = reference.get_bounding_box()
                 if reference_bb is not None:
-                    bb[0, 0] = min(bb[0, 0], reference_bb[0, 0])
-                    bb[0, 1] = min(bb[0, 1], reference_bb[0, 1])
-                    bb[1, 0] = max(bb[1, 0], reference_bb[1, 0])
-                    bb[1, 1] = max(bb[1, 1], reference_bb[1, 1])
+                    all_polygons.extend([reference_bb])
             if len(all_polygons) > 0:
                 all_points = numpy.concatenate(all_polygons).transpose()
                 bb[0, 0] = min(bb[0, 0], all_points[0].min())
                 bb[0, 1] = min(bb[0, 1], all_points[1].min())
                 bb[1, 0] = max(bb[1, 0], all_points[0].max())
                 bb[1, 1] = max(bb[1, 1], all_points[1].max())
+            else:
+                return None
             self._bb_valid = True
             self._bounding_box = bb
         return numpy.array(self._bounding_box)

--- a/gdspy/library.py
+++ b/gdspy/library.py
@@ -578,11 +578,11 @@ class Cell(object):
                 bb[0, 1] = min(bb[0, 1], all_points[1].min())
                 bb[1, 0] = max(bb[1, 0], all_points[0].max())
                 bb[1, 1] = max(bb[1, 1], all_points[1].max())
+                self._bounding_box = numpy.asarray(bb)
             else:
-                return None
+                self._bounding_box = None
             self._bb_valid = True
-            self._bounding_box = bb
-        return numpy.array(self._bounding_box)
+        return self._bounding_box
 
     def get_polygons(self, by_spec=False, depth=None):
         """

--- a/tests/cell.py
+++ b/tests/cell.py
@@ -293,6 +293,26 @@ def test_bounding_box():
 
     assert_bb(cell6.get_bounding_box(), ((2, 0), (3, 1)))
 
+    cell7a = gdspy.Cell("7a")
+
+    assert cell7a.get_bounding_box() is None
+
+    cell7b = gdspy.Cell("7b")
+    cell7b.add(gdspy.CellReference(cell7a, rotation=90))
+
+    assert cell7b.get_bounding_box() is None
+
+    cell7c = gdspy.Cell("7c")
+    cell7c.add(gdspy.CellReference(cell7b))
+
+    assert cell7c.get_bounding_box() is None
+
+    cell7 = gdspy.Cell("7")
+    cell7.add(cell1)
+    cell7.add(cell7c)
+
+    assert_bb(cell7.get_bounding_box(), ((0, 0), (1, 1)))
+
 
 def test_bounding_box2():
     cell0 = gdspy.Cell("0")


### PR DESCRIPTION
fixes case where cell is full of references which yield no valid polygons or bounding boxes and ends up returning initialization value