### PR TITLE
adding missing import of warnings module

### DIFF
--- a/gdspy/label.py
+++ b/gdspy/label.py
@@ -13,6 +13,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 
 import sys
+import warnings
 
 if sys.version_info.major < 3:
     from builtins import zip


### PR DESCRIPTION
warnings module is referenced on line 262 of label.py, but it is never imported. currently an error is thrown when we reach that branch (when properties >128 Bytes are found). this MR imports warnings in the label module to fix this error.