### PR TITLE
Fix a warning from new setuptools

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ formats=zip
 formats=wininst
 
 [bdist_wininst]
-user-access-control=auto
+user_access_control=auto
 
 [build_sphinx]
 source-dir=docs


### PR DESCRIPTION
```
/usr/lib/python3.9/site-packages/setuptools/dist.py:642: UserWarning: Usage of dash-separated 'user-access-control' will not be supported in future versions. Please use the underscore name 'user_access_control' instead
  warnings.warn(
```