### PR TITLE
enable fixed timestamp

### DIFF
--- a/gdspy/library.py
+++ b/gdspy/library.py
@@ -2411,7 +2411,7 @@ class GdsLibrary(object):
         if len(cells) == 0:
             warnings.warn("[GDSPY] Creating a GDSII file without any cells.")
         for cell in cells:
-            cell.to_gds(outfile, self.unit / self.precision)
+            cell.to_gds(outfile, self.unit / self.precision, timestamp=timestamp)
         if binary_cells is not None:
             for bc in binary_cells:
                 outfile.write(bc)


### PR DESCRIPTION
Hi Lucas,

This fix, enables fixed timestamp in saved cells, which allows having the same hash for files that do not change

You can see the test failing here, until the next gdspy release comes out
https://github.com/gdsfactory/gdsfactory/blob/253/pp/tests/test_hash.py

something I was not able to fix was the case that contains a CellArray on the same test_file. How could we fix that?
