### PR TITLE
adds tests to ensure that gds files with frozen timestamps have consistent hashes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ docs/_build/
 
 # PyBuilder
 target/
+tests/tmp/

--- a/gdspy/__init__.py
+++ b/gdspy/__init__.py
@@ -45,7 +45,7 @@ from gdspy.polygon import (
     PolyPath,
     L1Path,
 )
-from gdspy.gdsiiformat import gdsii_hash
+from gdspy.gdsiiformat import gdsii_hash, set_gdsii_timestamp
 from gdspy.operation import slice, offset, boolean, inside, copy
 
 try:

--- a/tests/cell.py
+++ b/tests/cell.py
@@ -6,9 +6,6 @@
 #  LICENSE file or <http://www.boost.org/LICENSE_1_0.txt>            #
 #                                                                    #
 ######################################################################
-import datetime
-import hashlib
-import pathlib
 
 import pytest
 import gdspy
@@ -356,74 +353,3 @@ def test_bounding_box2():
     cell6.add(gdspy.CellArray(cell1, 1, 1, (1, 1), origin=(2, 0)))
 
     assert_bb(cell6.get_bounding_box(), ((2, 0), (3, 1)))
-
-
-def hash_file(filepath):
-    filepath = pathlib.Path(filepath)
-    md5 = hashlib.md5()
-    md5.update(filepath.read_bytes())
-    return md5.hexdigest()
-
-
-def test_time_changes_gds_hash(tmpdir):
-    fn1 = str(tmpdir.join('nofreeze1.gds'))
-    fn2 = str(tmpdir.join('nofreeze2.gds'))
-    date1 = datetime.datetime(1988, 8, 28)
-    date2 = datetime.datetime(2020, 12, 25)
-    lib = gdspy.GdsLibrary(name='speedy')
-    lib.write_gds(fn1, timestamp=date1)
-    hash1 = hash_file(fn1)
-    lib.write_gds(fn2, timestamp=date2)
-    hash2 = hash_file(fn2)
-
-    assert hash1 != hash2
-
-
-def test_frozen_gds_has_constant_hash(tmpdir):
-    fn1 = str(tmpdir.join('freeze1.gds'))
-    fn2 = str(tmpdir.join('freeze2.gds'))
-    frozen_date = datetime.datetime(1988, 8, 28)
-    lib = gdspy.GdsLibrary(name='Elsa')
-    lib.write_gds(fn1, timestamp=frozen_date)
-    hash1 = hash_file(fn1)
-    lib.write_gds(fn2, timestamp=frozen_date)
-    hash2 = hash_file(fn2)
-
-    assert hash1 == hash2
-
-
-def test_frozen_gds_with_cell_has_constant_hash(tmpdir):
-    fn1 = str(tmpdir.join('freezec1.gds'))
-    fn2 = str(tmpdir.join('freezec2.gds'))
-    frozen_date = datetime.datetime(1988, 8, 28)
-    lib = gdspy.GdsLibrary(name='Elsa')
-    cell = gdspy.Cell(name='Anna')
-    cell.add(gdspy.Rectangle((0, 0), (100, 1000)))
-    lib.add(cell)
-    lib.write_gds(fn1, timestamp=frozen_date)
-    hash1 = hash_file(fn1)
-    lib.write_gds(fn2, timestamp=frozen_date)
-    hash2 = hash_file(fn2)
-
-    assert hash1 == hash2
-
-
-def test_frozen_gds_with_cell_array_has_constant_hash(tmpdir):
-    fn1 = str(tmpdir.join('freezea1.gds'))
-    fn2 = str(tmpdir.join('freezea2.gds'))
-    frozen_date = datetime.datetime(1988, 8, 28)
-    lib = gdspy.GdsLibrary(name='Elsa')
-    cell = gdspy.Cell(name='Anna')
-    cell.add(gdspy.Rectangle((0, 0), (100, 1000)))
-    cell2 = gdspy.Cell(name='Olaf')
-    cell2.add(gdspy.Rectangle((0, 0), (50, 100)))
-
-    cell_array = gdspy.CellArray(ref_cell=cell2, columns=5, rows=2, spacing=(60, 120), origin=(1000, 0))
-    cell.add(cell_array)
-    lib.add(cell)
-    lib.write_gds(fn1, timestamp=frozen_date)
-    hash1 = hash_file(fn1)
-    lib.write_gds(fn2, timestamp=frozen_date)
-    hash2 = hash_file(fn2)
-
-    assert hash1 == hash2

--- a/tests/cell.py
+++ b/tests/cell.py
@@ -372,8 +372,8 @@ def hash_file(filepath):
 def test_time_changes_gds_hash():
     fn1 = tmpdir / 'nofreeze1.gds'
     fn2 = tmpdir / 'nofreeze2.gds'
-    date1 = datetime.datetime.fromisocalendar(1988, 1, 1)
-    date2 = datetime.datetime.fromisocalendar(2021, 1, 1)
+    date1 = datetime.datetime(1988, 8, 28)
+    date2 = datetime.datetime(2020, 12, 25)
     lib = gdspy.GdsLibrary(name='speedy')
     lib.write_gds(fn1, timestamp=date1)
     hash1 = hash_file(fn1)
@@ -386,7 +386,7 @@ def test_time_changes_gds_hash():
 def test_frozen_gds_has_constant_hash():
     fn1 = tmpdir / 'freeze1.gds'
     fn2 = tmpdir / 'freeze2.gds'
-    frozen_date = datetime.datetime.fromisocalendar(1988, 1, 1)
+    frozen_date = datetime.datetime(1988, 8, 28)
     lib = gdspy.GdsLibrary(name='Elsa')
     lib.write_gds(fn1, timestamp=frozen_date)
     hash1 = hash_file(fn1)
@@ -399,7 +399,7 @@ def test_frozen_gds_has_constant_hash():
 def test_frozen_gds_with_cell_has_constant_hash():
     fn1 = tmpdir / 'freezec1.gds'
     fn2 = tmpdir / 'freezec2.gds'
-    frozen_date = datetime.datetime.fromisocalendar(1988, 1, 1)
+    frozen_date = datetime.datetime(1988, 8, 28)
     lib = gdspy.GdsLibrary(name='Elsa')
     cell = gdspy.Cell(name='Anna')
     cell.add(gdspy.Rectangle((0, 0), (100, 1000)))
@@ -415,7 +415,7 @@ def test_frozen_gds_with_cell_has_constant_hash():
 def test_frozen_gds_with_cell_array_has_constant_hash():
     fn1 = tmpdir / 'freezea1.gds'
     fn2 = tmpdir / 'freezea2.gds'
-    frozen_date = datetime.datetime.fromisocalendar(1988, 1, 1)
+    frozen_date = datetime.datetime(1988, 8, 28)
     lib = gdspy.GdsLibrary(name='Elsa')
     cell = gdspy.Cell(name='Anna')
     cell.add(gdspy.Rectangle((0, 0), (100, 1000)))

--- a/tests/cell.py
+++ b/tests/cell.py
@@ -18,10 +18,6 @@ import os
 
 gdspy.library.use_current_library = False
 
-tmpdir = pathlib.Path(__file__).parent / 'tmp'
-if not tmpdir.is_dir():
-    tmpdir.mkdir()
-
 
 def unique():
     return str(uuid.uuid4())
@@ -369,9 +365,9 @@ def hash_file(filepath):
     return md5.hexdigest()
 
 
-def test_time_changes_gds_hash():
-    fn1 = tmpdir / 'nofreeze1.gds'
-    fn2 = tmpdir / 'nofreeze2.gds'
+def test_time_changes_gds_hash(tmpdir):
+    fn1 = str(tmpdir.join('nofreeze1.gds'))
+    fn2 = str(tmpdir.join('nofreeze2.gds'))
     date1 = datetime.datetime(1988, 8, 28)
     date2 = datetime.datetime(2020, 12, 25)
     lib = gdspy.GdsLibrary(name='speedy')
@@ -383,9 +379,9 @@ def test_time_changes_gds_hash():
     assert hash1 != hash2
 
 
-def test_frozen_gds_has_constant_hash():
-    fn1 = tmpdir / 'freeze1.gds'
-    fn2 = tmpdir / 'freeze2.gds'
+def test_frozen_gds_has_constant_hash(tmpdir):
+    fn1 = str(tmpdir.join('freeze1.gds'))
+    fn2 = str(tmpdir.join('freeze2.gds'))
     frozen_date = datetime.datetime(1988, 8, 28)
     lib = gdspy.GdsLibrary(name='Elsa')
     lib.write_gds(fn1, timestamp=frozen_date)
@@ -396,9 +392,9 @@ def test_frozen_gds_has_constant_hash():
     assert hash1 == hash2
 
 
-def test_frozen_gds_with_cell_has_constant_hash():
-    fn1 = tmpdir / 'freezec1.gds'
-    fn2 = tmpdir / 'freezec2.gds'
+def test_frozen_gds_with_cell_has_constant_hash(tmpdir):
+    fn1 = str(tmpdir.join('freezec1.gds'))
+    fn2 = str(tmpdir.join('freezec2.gds'))
     frozen_date = datetime.datetime(1988, 8, 28)
     lib = gdspy.GdsLibrary(name='Elsa')
     cell = gdspy.Cell(name='Anna')
@@ -412,9 +408,9 @@ def test_frozen_gds_with_cell_has_constant_hash():
     assert hash1 == hash2
 
 
-def test_frozen_gds_with_cell_array_has_constant_hash():
-    fn1 = tmpdir / 'freezea1.gds'
-    fn2 = tmpdir / 'freezea2.gds'
+def test_frozen_gds_with_cell_array_has_constant_hash(tmpdir):
+    fn1 = str(tmpdir.join('freezea1.gds'))
+    fn2 = str(tmpdir.join('freezea2.gds'))
     frozen_date = datetime.datetime(1988, 8, 28)
     lib = gdspy.GdsLibrary(name='Elsa')
     cell = gdspy.Cell(name='Anna')

--- a/tests/cell.py
+++ b/tests/cell.py
@@ -6,6 +6,9 @@
 #  LICENSE file or <http://www.boost.org/LICENSE_1_0.txt>            #
 #                                                                    #
 ######################################################################
+import datetime
+import hashlib
+import pathlib
 
 import pytest
 import gdspy
@@ -14,6 +17,10 @@ import uuid
 import os
 
 gdspy.library.use_current_library = False
+
+tmpdir = pathlib.Path(__file__).parent / 'tmp'
+if not tmpdir.is_dir():
+    tmpdir.mkdir()
 
 
 def unique():
@@ -353,3 +360,74 @@ def test_bounding_box2():
     cell6.add(gdspy.CellArray(cell1, 1, 1, (1, 1), origin=(2, 0)))
 
     assert_bb(cell6.get_bounding_box(), ((2, 0), (3, 1)))
+
+
+def hash_file(filepath):
+    filepath = pathlib.Path(filepath)
+    md5 = hashlib.md5()
+    md5.update(filepath.read_bytes())
+    return md5.hexdigest()
+
+
+def test_time_changes_gds_hash():
+    fn1 = tmpdir / 'nofreeze1.gds'
+    fn2 = tmpdir / 'nofreeze2.gds'
+    date1 = datetime.datetime.fromisocalendar(1988, 1, 1)
+    date2 = datetime.datetime.fromisocalendar(2021, 1, 1)
+    lib = gdspy.GdsLibrary(name='speedy')
+    lib.write_gds(fn1, timestamp=date1)
+    hash1 = hash_file(fn1)
+    lib.write_gds(fn2, timestamp=date2)
+    hash2 = hash_file(fn2)
+
+    assert hash1 != hash2
+
+
+def test_frozen_gds_has_constant_hash():
+    fn1 = tmpdir / 'freeze1.gds'
+    fn2 = tmpdir / 'freeze2.gds'
+    frozen_date = datetime.datetime.fromisocalendar(1988, 1, 1)
+    lib = gdspy.GdsLibrary(name='Elsa')
+    lib.write_gds(fn1, timestamp=frozen_date)
+    hash1 = hash_file(fn1)
+    lib.write_gds(fn2, timestamp=frozen_date)
+    hash2 = hash_file(fn2)
+
+    assert hash1 == hash2
+
+
+def test_frozen_gds_with_cell_has_constant_hash():
+    fn1 = tmpdir / 'freezec1.gds'
+    fn2 = tmpdir / 'freezec2.gds'
+    frozen_date = datetime.datetime.fromisocalendar(1988, 1, 1)
+    lib = gdspy.GdsLibrary(name='Elsa')
+    cell = gdspy.Cell(name='Anna')
+    cell.add(gdspy.Rectangle((0, 0), (100, 1000)))
+    lib.add(cell)
+    lib.write_gds(fn1, timestamp=frozen_date)
+    hash1 = hash_file(fn1)
+    lib.write_gds(fn2, timestamp=frozen_date)
+    hash2 = hash_file(fn2)
+
+    assert hash1 == hash2
+
+
+def test_frozen_gds_with_cell_array_has_constant_hash():
+    fn1 = tmpdir / 'freezea1.gds'
+    fn2 = tmpdir / 'freezea2.gds'
+    frozen_date = datetime.datetime.fromisocalendar(1988, 1, 1)
+    lib = gdspy.GdsLibrary(name='Elsa')
+    cell = gdspy.Cell(name='Anna')
+    cell.add(gdspy.Rectangle((0, 0), (100, 1000)))
+    cell2 = gdspy.Cell(name='Olaf')
+    cell2.add(gdspy.Rectangle((0, 0), (50, 100)))
+
+    cell_array = gdspy.CellArray(ref_cell=cell2, columns=5, rows=2, spacing=(60, 120), origin=(1000, 0))
+    cell.add(cell_array)
+    lib.add(cell)
+    lib.write_gds(fn1, timestamp=frozen_date)
+    hash1 = hash_file(fn1)
+    lib.write_gds(fn2, timestamp=frozen_date)
+    hash2 = hash_file(fn2)
+
+    assert hash1 == hash2

--- a/tests/functions.py
+++ b/tests/functions.py
@@ -12,6 +12,7 @@ import io
 import datetime
 import numpy
 import gdspy
+from tutils import hash_file
 
 gdspy.library.use_current_library = False
 
@@ -328,3 +329,22 @@ def test_missing_ca(tmpdir):
     out = str(tmpdir.join("test.gds"))
     now = datetime.datetime.today()
     lib.write_gds(out, timestamp=now)
+
+
+def test_update_timestamp(tmpdir):
+    fn1 = str(tmpdir.join('nofreeze1.gds'))
+    fn2 = str(tmpdir.join('nofreeze2.gds'))
+    date1 = datetime.datetime(1988, 8, 28)
+    date2 = datetime.datetime(2020, 12, 25)
+    lib = gdspy.GdsLibrary(name='speedy')
+    lib.write_gds(fn1, timestamp=date1)
+    hash1 = hash_file(fn1)
+    lib.write_gds(fn2, timestamp=date2)
+    hash2 = hash_file(fn2)
+
+    assert hash1 != hash2
+
+    gdspy.set_gdsii_timestamp(filename=fn2, timestamp=date1)
+    hash3 = hash_file(fn2)
+
+    assert hash1 == hash3

--- a/tests/gdslibrary.py
+++ b/tests/gdslibrary.py
@@ -10,6 +10,8 @@
 import pytest
 import gdspy
 import uuid
+import datetime
+from tutils import hash_file
 
 gdspy.library.use_current_library = False
 
@@ -393,3 +395,67 @@ def test_properties(tmpdir):
     assert fp.properties == lib1.cells["FP"].paths[0].properties
     assert rp.properties == lib1.cells["RP"].paths[0].properties
     assert rp.properties == lib1.cells["RP"].paths[1].properties
+
+
+def test_time_changes_gds_hash(tmpdir):
+    fn1 = str(tmpdir.join('nofreeze1.gds'))
+    fn2 = str(tmpdir.join('nofreeze2.gds'))
+    date1 = datetime.datetime(1988, 8, 28)
+    date2 = datetime.datetime(2020, 12, 25)
+    lib = gdspy.GdsLibrary(name='speedy')
+    lib.write_gds(fn1, timestamp=date1)
+    hash1 = hash_file(fn1)
+    lib.write_gds(fn2, timestamp=date2)
+    hash2 = hash_file(fn2)
+
+    assert hash1 != hash2
+
+
+def test_frozen_gds_has_constant_hash(tmpdir):
+    fn1 = str(tmpdir.join('freeze1.gds'))
+    fn2 = str(tmpdir.join('freeze2.gds'))
+    frozen_date = datetime.datetime(1988, 8, 28)
+    lib = gdspy.GdsLibrary(name='Elsa')
+    lib.write_gds(fn1, timestamp=frozen_date)
+    hash1 = hash_file(fn1)
+    lib.write_gds(fn2, timestamp=frozen_date)
+    hash2 = hash_file(fn2)
+
+    assert hash1 == hash2
+
+
+def test_frozen_gds_with_cell_has_constant_hash(tmpdir):
+    fn1 = str(tmpdir.join('freezec1.gds'))
+    fn2 = str(tmpdir.join('freezec2.gds'))
+    frozen_date = datetime.datetime(1988, 8, 28)
+    lib = gdspy.GdsLibrary(name='Elsa')
+    cell = gdspy.Cell(name='Anna')
+    cell.add(gdspy.Rectangle((0, 0), (100, 1000)))
+    lib.add(cell)
+    lib.write_gds(fn1, timestamp=frozen_date)
+    hash1 = hash_file(fn1)
+    lib.write_gds(fn2, timestamp=frozen_date)
+    hash2 = hash_file(fn2)
+
+    assert hash1 == hash2
+
+
+def test_frozen_gds_with_cell_array_has_constant_hash(tmpdir):
+    fn1 = str(tmpdir.join('freezea1.gds'))
+    fn2 = str(tmpdir.join('freezea2.gds'))
+    frozen_date = datetime.datetime(1988, 8, 28)
+    lib = gdspy.GdsLibrary(name='Elsa')
+    cell = gdspy.Cell(name='Anna')
+    cell.add(gdspy.Rectangle((0, 0), (100, 1000)))
+    cell2 = gdspy.Cell(name='Olaf')
+    cell2.add(gdspy.Rectangle((0, 0), (50, 100)))
+
+    cell_array = gdspy.CellArray(ref_cell=cell2, columns=5, rows=2, spacing=(60, 120), origin=(1000, 0))
+    cell.add(cell_array)
+    lib.add(cell)
+    lib.write_gds(fn1, timestamp=frozen_date)
+    hash1 = hash_file(fn1)
+    lib.write_gds(fn2, timestamp=frozen_date)
+    hash2 = hash_file(fn2)
+
+    assert hash1 == hash2

--- a/tests/gdswriter.py
+++ b/tests/gdswriter.py
@@ -6,8 +6,6 @@
 #  LICENSE file or <http://www.boost.org/LICENSE_1_0.txt>            #
 #                                                                    #
 ######################################################################
-import datetime
-import hashlib
 import gdspy
 
 gdspy.library.use_current_library = False
@@ -96,74 +94,3 @@ def test_writer_gds(tmpdir):
     assert lib2.name == "lib2"
     assert len(lib2.cells) == 4
 
-
-def hash_file(filepath):
-    md5 = hashlib.md5()
-    with open(filepath, mode='rb') as f:
-        content = f.read()
-        md5.update(content)
-    return md5.hexdigest()
-
-
-def test_time_changes_gds_hash(tmpdir):
-    fn1 = str(tmpdir.join('nofreeze1.gds'))
-    fn2 = str(tmpdir.join('nofreeze2.gds'))
-    date1 = datetime.datetime(1988, 8, 28)
-    date2 = datetime.datetime(2020, 12, 25)
-    lib = gdspy.GdsLibrary(name='speedy')
-    lib.write_gds(fn1, timestamp=date1)
-    hash1 = hash_file(fn1)
-    lib.write_gds(fn2, timestamp=date2)
-    hash2 = hash_file(fn2)
-
-    assert hash1 != hash2
-
-
-def test_frozen_gds_has_constant_hash(tmpdir):
-    fn1 = str(tmpdir.join('freeze1.gds'))
-    fn2 = str(tmpdir.join('freeze2.gds'))
-    frozen_date = datetime.datetime(1988, 8, 28)
-    lib = gdspy.GdsLibrary(name='Elsa')
-    lib.write_gds(fn1, timestamp=frozen_date)
-    hash1 = hash_file(fn1)
-    lib.write_gds(fn2, timestamp=frozen_date)
-    hash2 = hash_file(fn2)
-
-    assert hash1 == hash2
-
-
-def test_frozen_gds_with_cell_has_constant_hash(tmpdir):
-    fn1 = str(tmpdir.join('freezec1.gds'))
-    fn2 = str(tmpdir.join('freezec2.gds'))
-    frozen_date = datetime.datetime(1988, 8, 28)
-    lib = gdspy.GdsLibrary(name='Elsa')
-    cell = gdspy.Cell(name='Anna')
-    cell.add(gdspy.Rectangle((0, 0), (100, 1000)))
-    lib.add(cell)
-    lib.write_gds(fn1, timestamp=frozen_date)
-    hash1 = hash_file(fn1)
-    lib.write_gds(fn2, timestamp=frozen_date)
-    hash2 = hash_file(fn2)
-
-    assert hash1 == hash2
-
-
-def test_frozen_gds_with_cell_array_has_constant_hash(tmpdir):
-    fn1 = str(tmpdir.join('freezea1.gds'))
-    fn2 = str(tmpdir.join('freezea2.gds'))
-    frozen_date = datetime.datetime(1988, 8, 28)
-    lib = gdspy.GdsLibrary(name='Elsa')
-    cell = gdspy.Cell(name='Anna')
-    cell.add(gdspy.Rectangle((0, 0), (100, 1000)))
-    cell2 = gdspy.Cell(name='Olaf')
-    cell2.add(gdspy.Rectangle((0, 0), (50, 100)))
-
-    cell_array = gdspy.CellArray(ref_cell=cell2, columns=5, rows=2, spacing=(60, 120), origin=(1000, 0))
-    cell.add(cell_array)
-    lib.add(cell)
-    lib.write_gds(fn1, timestamp=frozen_date)
-    hash1 = hash_file(fn1)
-    lib.write_gds(fn2, timestamp=frozen_date)
-    hash2 = hash_file(fn2)
-
-    assert hash1 == hash2

--- a/tests/tutils.py
+++ b/tests/tutils.py
@@ -10,6 +10,7 @@
 import os
 import pytest
 import gdspy
+import hashlib
 
 gdspy.library.use_current_library = False
 
@@ -56,3 +57,11 @@ def assertsame(c1, c2, tolerance=1e-6):
             assert r2 is None
         else:
             assert result is None
+
+
+def hash_file(filepath):
+    md5 = hashlib.md5()
+    with open(filepath, mode='rb') as f:
+        content = f.read()
+        md5.update(content)
+    return md5.hexdigest()


### PR DESCRIPTION
This PR adds new tests to ensure that 
1. GDS files with different timestamps have different hashes
2. GDS files with identical timestamps have identical hashes
    - when empty
    - with cells
    - with cell arrays