### PR TITLE
raise ValueError for duplicated_cells

### DIFF
--- a/gdspy/library.py
+++ b/gdspy/library.py
@@ -2632,7 +2632,7 @@ class GdsLibrary(object):
                     name = rename_template.format(name=record[1])
                 cell = Cell(name, exclude_from_current=True)
                 if name in self.cells:
-                    raise ValueError(f"Multiple cells with name: {name} in GDS file")
+                    raise ValueError("[GDSPY] Multiple cells with name: {0} in GDSII file".format(name))
                 self.cells[name] = cell
             # STRING
             elif record[0] == 0x19:

--- a/gdspy/library.py
+++ b/gdspy/library.py
@@ -2631,6 +2631,8 @@ class GdsLibrary(object):
                 else:
                     name = rename_template.format(name=record[1])
                 cell = Cell(name, exclude_from_current=True)
+                if name in self.cells:
+                    raise ValueError(f"Multiple cells with name: {name} in GDS file")
                 self.cells[name] = cell
             # STRING
             elif record[0] == 0x19:


### PR DESCRIPTION
Hi Lucas,

Currently when importing a GDS we map the cells in a dictionary.
This can have unintended consequences when loading GDS files that have duplicated cells

i think raising an error is safer,
this is inspired in another tool that I was using for checking for duplicated cells in GDS files

```
from klamath.library import scan_structs

def check_duplicate_cells(gdspath: PathType):
    with open(gdspath, "rb") as f:
        scan_structs(f)
```