### PR TITLE
speed improvement in remove_polygons

### DIFF
--- a/gdspy/library.py
+++ b/gdspy/library.py
@@ -367,22 +367,19 @@ class Cell(object):
         >>> cell.remove_polygons(lambda pts, layer, datatype:
         ...                      any(pts[:, 0] < 0))
         """
-        empty = []
+        filtered_polys = []
         for element in self.polygons:
-            ii = 0
-            while ii < len(element.polygons):
-                if test(
-                    element.polygons[ii], element.layers[ii], element.datatypes[ii]
-                ):
-                    element.polygons.pop(ii)
-                    element.layers.pop(ii)
-                    element.datatypes.pop(ii)
-                else:
-                    ii += 1
-            if len(element.polygons) == 0:
-                empty.append(element)
-        for element in empty:
-            self.polygons.remove(element)
+            pld = [(poly, l, dt) for poly, l, dt in zip(element.polygons, element.layers, element.datatypes)
+                   if not test(poly, l, dt)]
+            if len(pld) == 0:
+                pass  # we don't need no empty polygons!
+            else:
+                polys, layers, dts = zip(*pld)
+                element.polygons = polys
+                element.layers = layers
+                element.datatypes = dts
+                filtered_polys.append(element)
+        self.polygons = filtered_polys
         return self
 
     def remove_paths(self, test):


### PR DESCRIPTION
Removal of an item from a list at an arbitrary index in python is an O(N) operation. Repeatedly doing this over a list can be very costly, as is done in the current `remove_polygons()` function. This MR instead filters the existing list into a new list via a list comprehension, which is much faster in scenarios where there are many polygons to remove.