### PR TITLE
Fix negative keys in properties dictionary when reading GDSII files

### DIFF
--- a/gdspy/library.py
+++ b/gdspy/library.py
@@ -2714,7 +2714,7 @@ class GdsLibrary(object):
                         ref.ref_cell = self.cells[ref.ref_cell]
             # PROPATTR
             elif record[0] == 0x2B:
-                attr = record[1][0]
+                attr = record[1][0] & 0xFFFF  # Convert to unsigned 16-bit integer
             # PROPVALUE
             elif record[0] == 0x2C:
                 properties[attr] = record[1]

--- a/tests/gdslibrary.py
+++ b/tests/gdslibrary.py
@@ -361,6 +361,8 @@ def test_properties(tmpdir):
     rect = gdspy.Rectangle((0, 0), (2, 1))
     rect.properties[1] = "test1"
     rect.properties[126] = "test_126"
+    # Add a property with a key value ≥2**16//2, see PR #240
+    rect.properties[2**16//2] = "test_large_key"
     lbl = gdspy.Label("LABEL", (20, 20))
     lbl.properties[2] = "test2"
     lbl.properties[22] = "test22"


### PR DESCRIPTION
## Problem
When reading GDSII files using the `read_gds` function in `gdspy`, there is an issue with how the properties are handled. The `attr` value, which is used as the key in the `properties` dictionary, is directly obtained from the GDSII file without any conversion or checking. If the `attr` value is greater than 32767, it is interpreted as a negative number due to the signed integer representation.

This leads to a problem where keys greater than 32767 are stored as negative values in the `properties` dictionary when reading the GDSII file.

It's important to note that when saving properties using the `write_gds` function in `gdspy`, the keys are directly written to the GDSII file as unsigned 16-bit integers (2 bytes). The `struct.pack` function is used with the format string `">5H"`, where `"H"` represents an unsigned short integer. This ensures that the keys are correctly stored as unsigned values in the range of 0 to 65535.

However, when reading the GDSII file using the `read_gds` function, the `attr` values are interpreted as signed integers, leading to the issue of negative keys for values greater than 32767.

## Solution
To fix this issue, the `read_gds` function has been modified to handle the `attr` value appropriately. The `attr` value is now converted to an unsigned 16-bit integer before being used as a key in the `properties` dictionary.

The relevant code changes are as follows:

```diff
# PROPATTR
elif record[0] == 0x2B:
-    attr = record[1][0]
+    attr = record[1][0] & 0xFFFF  # Convert to unsigned 16-bit integer
# PROPVALUE
elif record[0] == 0x2C:
    properties[attr] = record[1]
```

By performing a bitwise AND operation with `0xFFFF` (65535), the `attr` value is converted to an unsigned 16-bit integer, ensuring that it falls within the range of 0 to 65535.

This change aligns the behavior of the `read_gds` function with how the properties are saved using the `write_gds` function, maintaining consistency and avoiding the interpretation of keys as negative values.

## Impact
This fix resolves the issue of negative keys in the `properties` dictionary when reading GDSII files. It ensures that the keys in the `properties` dictionary are correctly stored as unsigned integers, matching the expected behavior and aligning with how the properties are saved.

Users of the `gdspy` library who rely on the `read_gds` function to read GDSII files with properties will benefit from this fix, as it will prevent unexpected negative keys in the resulting `properties` dictionary.

## Testing
The modified `read_gds` function has been tested with GDSII files containing properties with `attr` values greater than 32767. The fix has been verified to correctly store the keys as unsigned integers in the `properties` dictionary.

An existing unit tests has been moddified to ensure the correct behavior of the `read_gds` function when handling properties with large `attr` values. Previously having a key ≥2**16 would result in a negative number being loaded.